### PR TITLE
Exchange conda dependencies by requirements.txt

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,27 +1,9 @@
 name: Met4FoF_Code
 channels:
     - defaults
-    - conda-forge
 dependencies:
     - python >= 3
-    - ipykernel
-    - jupyter
-    - numpy
-    - scikit-learn
-    - scikit-multiflow
-    - scipy
-    - matplotlib
-    - pandas
-    - seaborn
-    - dash
-    - networkx
-    - multiprocess
-    - h5py
-    - requests
-    - pytest
-    - sympy
     # pip dependencies have to be provided in `requirements.txt` syntax
     - pip:
-        - osbrain
-        - dash-cytoscape
-        - plotly
+        - -r requirements.txt
+


### PR DESCRIPTION
This resolves the issue with the failing pipelines for conda builds by exchanging the *environment.yml*'s content by the *pip* way `-r requirements.txt`.