### PR TITLE
Update agentMET4FOF with fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,7 +421,7 @@ jobs:
          command: |
            python3 -m venv venv
            source venv/bin/activate
-           pip install --upgrade pip-r agentMET4FOF/requirements.txt -r agentMET4FOF/dev-requirements.txt
+           pip install --upgrade pip -r agentMET4FOF/requirements.txt -r agentMET4FOF/dev-requirements.txt
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,7 +411,7 @@ jobs:
       - restore_cache:
           keys:
             # Specify the unique identifier for the cache.
-            - agentMET4FOF-v1-{{ checksum "agentMET4FOF/requirements.txt" }}
+            - agentMET4FOF-v1-{{ checksum "agentMET4FOF/requirements.txt" }}-{{ checksum "agentMET4FOF/dev-requirements.txt" }}
             # Fallback to using the latest cache if no exact match is found.
             - agentMET4FOF-v1
 
@@ -421,14 +421,13 @@ jobs:
          command: |
            python3 -m venv venv
            source venv/bin/activate
-           pip install --upgrade pip pytest
-           pip install -r agentMET4FOF/requirements.txt
+           pip install --upgrade pip-r agentMET4FOF/requirements.txt -r agentMET4FOF/dev-requirements.txt
 
       - save_cache:
           paths:
             - ./venv
           key: >-
-            agentMET4FOF-v1-{{ checksum "agentMET4FOF/requirements.txt" }}
+            agentMET4FOF-v1-{{ checksum "agentMET4FOF/requirements.txt" }}-{{ checksum "agentMET4FOF/dev-requirements.txt" }}
 
       # Run tests! We use pytest's test-runner.
       - run_venv_tests:


### PR DESCRIPTION
This brings agentMET4FOF to the latest release containing the fix for the broken matplotlib dependency.