### PR TITLE
Upgrade python semantic release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,24 @@
 <!--next-version-placeholder-->
 
 ## v0.10.0 (2020-11-06)
-### Feature
-* Add a method to shift a vector with associated uncertainty ([`01c1fb2`](https://github.com/Met4FoF/Code/commit/01c1fb21c29a9ec300f4e1008389631fe74daeec))
-* Handle case of no filter uncertainty ([`63ca553`](https://github.com/Met4FoF/Code/commit/63ca553170453870b9113e7fbbb6d9262fd7414e))
 
-### Fix
-* Flip theta in uncertainty formulas of FIRuncFilter ([`dd04eea`](https://github.com/Met4FoF/Code/commit/dd04eeace70ce4fe7a81fb432cc117f80af74d4f))
-* Prepend xlow with constant value ([`f481845`](https://github.com/Met4FoF/Code/commit/f481845e6392a024933b4e79b3a64b6c63915ee5))
-* Insert assertion that sigma_noise must be 1D ([`113bc10`](https://github.com/Met4FoF/Code/commit/113bc10b6bc48bf1e5052a38ac9fd4fc5450feb7))
-* Insert assertion that sigma_noise must be 1D ([`d984975`](https://github.com/Met4FoF/Code/commit/d9849756a71f0c1ec9d0df63aaf418fd95340cc0))
-* Fix a bug in `interp1d_unc` resulting from relying on default values ([`8fb7c3a`](https://github.com/Met4FoF/Code/commit/8fb7c3ababd3346e3bae104947270379b432bd61))
+### Updated repositories
 
-### Documentation
-* Include new interpolation tutorials into docs ([`bcd3e89`](https://github.com/Met4FoF/Code/commit/bcd3e89db9eb9996e73715895ac996120b73fbbf))
-* Insert important parameter `--force` into migration hint in _Code's_ _README_ ([`316838f`](https://github.com/Met4FoF/Code/commit/316838f75be3105565e075ea7c65cda8edcb4deb))
-* Drop Python 3.5 support because it reached EOL on 2020-09-13 ([`d09bda3`](https://github.com/Met4FoF/Code/commit/d09bda38ca6f2298096118356c5be594c98a817f))
-* Improve _CONTRIBUTING.md_ with further commit message conventions ([`4c047c5`](https://github.com/Met4FoF/Code/commit/4c047c51628f4c125774c2a225c9730226623eb2))
-* Update path to package diagram in _README.md_ ([`05c6007`](https://github.com/Met4FoF/Code/commit/05c6007fee987f0bd30d016513f13258abcc9cd6))
+In this release we updated
+
+- _agentMET4FOF_ to version 0.3.0,
+- _PyDynamic_ to version 1.6.1,
+- tutorials/_anomaly_detection_ to its current version relying on _agentMET4FOF_ version 0.2.0.
+
+#### PyDynamic improvements
+
+_PyDynamic_ has received two new features, some bug fixes and documentation improvements. The new features are:
+
+* Add a method `shift_uncertainty()` to shift a vector with associated uncertainty ([`2584ea1`](https://github.com/Met4FoF/Code/commit/2584ea1fffb828cec726434bf669738ed5c5d034))
+* Handle case of no filter uncertainty in `FIRuncFilter()` ([`63ca553`](https://github.com/Met4FoF/Code/commit/63ca553170453870b9113e7fbbb6d9262fd7414e))
+
+See the [PyDynamic releases](https://github.com/PTB-PSt1/PyDynamic/releases) for details.
+
+#### agentMET4FOF improvements
+
+_agentMET4FOF_ has evolved regarding the metrological agents quite a bit. Please check the [agentMET4FOF release](https://github.com/bangxiangyong/agentMET4FOF/releases/) page for details.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,42 @@
 [semantic_release]
+# The file(s) and variable name of where the version number is stored.
 version_variable=VERSION:__version__
+# The way we get and set the new version. Can be commit or tag.
+# If set to tag, will get the current version from the latest tag matching vX.Y.Z.
+# This won’t change the source defined in version_variable.
+# If set to commit, will get the current version from the source defined in
+# version_variable, edit the file and commit it.
 version_source=commit
+# Import path of a Python function that can parse commit messages and return
+# information about the commit.
+commit_parser=semantic_release.history.emoji_parser
+# Comma-separated list of emojis used by semantic_release.history.emoji_parser to
+# create major releases.
+major_emoji=:boom:
+# Comma-separated list of emojis used by semantic_release.history.emoji_parser to
+# create minor releases.
+minor_emoji=:sparkles:,:children_crossing:,:lipstick:,:iphone:,:egg:,:chart_with_upwards_trend:
+# Comma-separated list of emojis used by semantic_release.history.emoji_parser to
+# create patch releases.
+patch_emoji=:ambulance:,:lock:,:bug:,:zap:,:goal_net:,:alien:,:wheelchair:,:speech_balloon:,:mag:,:apple:,:penguin:,:checkered_flag:,:robot:,:green_apple:
+# If set to false the pypi uploading will be disabled.
 upload_to_pypi=false
-upload_to_release=false
+# If set to false, do not upload distributions to GitHub releases.
+upload_to_release=true
+# The branch to run releases from.
 branch=master
+# The name of your hvcs. Currently only GitHub and GitLab are supported.
 hvcs=github
+# Whether or not to commit changes when bumping version.
 commit_version_number=true
-compare_link=true
+# The name of the file where the changelog is kept, relative to the root of the repo.
+changelog_file=/CHANGELOG.md
+# Comma-separated list of sections to display in the changelog. They will be
+# displayed in the order they are given. The available options depend on the commit
+# parser used.
+changelog_sections=feature,fix,breaking,documentation,performance
+# A comma-separated list of the import paths of components to include in the changelog.
+changelog_components=semantic_release.changelog.changelog_headers,semantic_release.changelog.compare_url
+
+[rstcheck]
+ignore_messages=(No directive entry for "automodule" in module "docutils.parsers.rst.languages.en"\.$)

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,10 +33,9 @@ commit_version_number=true
 changelog_file=/CHANGELOG.md
 # Comma-separated list of sections to display in the changelog. They will be
 # displayed in the order they are given. The available options depend on the commit
-# parser used.
-changelog_sections=feature,fix,breaking,documentation,performance
+# parser used. We choose all possible emojis but none of the angular options, which
+# we assume to be used in the upstream repositories. This assures we keep control
+# over our changelog.
+changelog_sections=:boom:,:sparkles:,:children_crossing:,:lipstick:,:iphone:,:egg:,:chart_with_upwards_trend:,:ambulance:,:lock:,:bug:,:zap:,:goal_net:,:alien:,:wheelchair:,:speech_balloon:,:mag:,:apple:,:penguin:,:checkered_flag:,:robot:,:green_apple:,
 # A comma-separated list of the import paths of components to include in the changelog.
 changelog_components=semantic_release.changelog.changelog_headers,semantic_release.changelog.compare_url
-
-[rstcheck]
-ignore_messages=(No directive entry for "automodule" in module "docutils.parsers.rst.languages.en"\.$)

--- a/tutorials/agentMET4FOF_anomaly_detection/test_anomaly_detection/test_detection.py
+++ b/tutorials/agentMET4FOF_anomaly_detection/test_anomaly_detection/test_detection.py
@@ -20,7 +20,7 @@ def dashboard():
     dashboard.join()
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(10)
 @pytest.mark.usefixtures("dashboard")
 def test_dashboard():
     # This test calls demonstrate_generator_agent_use and waits for five seconds for the


### PR DESCRIPTION
Once we finished the fix of the failed anomaly_detection tests due to timeout, we will release these with the update python-semantic-release options based on emoji parsing.