### PR TITLE
Update deps

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -87,7 +87,7 @@ pygments==2.13.0
     # via
     #   -c requirements.txt
     #   readme-renderer
-python-gitlab==3.8.1
+python-gitlab==3.9.0
     # via
     #   -c requirements.txt
     #   python-semantic-release

--- a/requirements.txt
+++ b/requirements.txt
@@ -158,7 +158,7 @@ dill==0.3.5.1
     #   -c agentMET4FOF/requirements.txt
     #   multiprocess
     #   osbrain
-distlib==0.3.5
+distlib==0.3.6
     # via virtualenv
 docutils==0.17.1
     # via
@@ -512,7 +512,7 @@ python-dateutil==2.8.2
     #   jupyter-client
     #   matplotlib
     #   pandas
-python-gitlab==3.8.1
+python-gitlab==3.9.0
     # via python-semantic-release
 python-semantic-release==7.28.1
     # via


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after all subtrees were       successfully updated and afterwards the deps       were succesfully compiled. If all tests pass with the       new versions, it should be merged as soon as possible to       avoid any security issues due to outdated dependencies.