### PR TITLE
Update deps

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -57,16 +57,16 @@ idna==3.3
     # via
     #   -c requirements.txt
     #   requests
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via
     #   -c requirements.txt
     #   keyring
     #   twine
-invoke==1.7.1
+invoke==1.7.3
     # via
     #   -c requirements.txt
     #   python-semantic-release
-jaraco-classes==3.2.2
+jaraco-classes==3.2.3
     # via
     #   -c requirements.txt
     #   keyring
@@ -75,7 +75,7 @@ jeepney==0.8.0
     #   -c requirements.txt
     #   keyring
     #   secretstorage
-keyring==23.9.1
+keyring==23.9.3
     # via
     #   -c requirements.txt
     #   twine
@@ -95,7 +95,7 @@ pygments==2.13.0
     # via
     #   -c requirements.txt
     #   readme-renderer
-python-gitlab==3.9.0
+python-gitlab==3.10.0
     # via
     #   -c requirements.txt
     #   python-semantic-release
@@ -103,7 +103,7 @@ python-semantic-release==7.28.1
     # via
     #   -c requirements.txt
     #   -r dev-requirements.in
-readme-renderer==37.1
+readme-renderer==37.2
     # via
     #   -c requirements.txt
     #   twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -112,7 +112,7 @@ cookiecutter==2.1.1
     # via
     #   -c agentMET4FOF/requirements.txt
     #   mesa
-coverage[toml]==6.4.4
+coverage[toml]==6.5.0
     # via pytest-cov
 cryptography==38.0.1
     # via secretstorage
@@ -204,7 +204,7 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27
     # via python-semantic-release
-hypothesis==6.54.5
+hypothesis==6.55.0
     # via -r agentMET4FOF/dev-requirements.in
 idna==3.3
     # via
@@ -213,7 +213,7 @@ idna==3.3
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via
     #   flask
     #   keyring
@@ -224,7 +224,7 @@ importlib-resources==5.9.0
     # via jsonschema
 iniconfig==1.1.1
     # via pytest
-invoke==1.7.1
+invoke==1.7.3
     # via python-semantic-release
 ipython==8.4.0
     # via
@@ -235,7 +235,7 @@ itsdangerous==2.1.2
     # via
     #   -c agentMET4FOF/requirements.txt
     #   flask
-jaraco-classes==3.2.2
+jaraco-classes==3.2.3
     # via keyring
 jedi==0.18.1
     # via
@@ -259,7 +259,7 @@ jinja2-time==0.2.0
     # via
     #   -c agentMET4FOF/requirements.txt
     #   cookiecutter
-joblib==1.1.0
+joblib==1.2.0
     # via
     #   -c ZeMA_testbed_Bayesian_machine_learning/requirements.in
     #   scikit-learn
@@ -281,7 +281,7 @@ jupyterlab-pygments==0.2.2
     # via
     #   -c agentMET4FOF/requirements.txt
     #   nbconvert
-keyring==23.9.1
+keyring==23.9.3
     # via twine
 kiwisolver==1.4.4
     # via
@@ -502,7 +502,7 @@ pytest==7.1.3
     #   -r agentMET4FOF/dev-requirements.in
     #   pytest-cov
     #   pytest-timeout
-pytest-cov==3.0.0
+pytest-cov==4.0.0
     # via -r agentMET4FOF/dev-requirements.in
 pytest-timeout==2.1.0
     # via
@@ -516,7 +516,7 @@ python-dateutil==2.8.2
     #   jupyter-client
     #   matplotlib
     #   pandas
-python-gitlab==3.9.0
+python-gitlab==3.10.0
     # via python-semantic-release
 python-semantic-release==7.28.1
     # via
@@ -546,7 +546,7 @@ pyzmq==23.2.1
     #   -c agentMET4FOF/requirements.txt
     #   jupyter-client
     #   osbrain
-readme-renderer==37.1
+readme-renderer==37.2
     # via twine
 recommonmark==0.7.1
     # via
@@ -623,7 +623,7 @@ soupsieve==2.3.2.post1
     # via
     #   -c agentMET4FOF/requirements.txt
     #   beautifulsoup4
-sphinx==5.1.1
+sphinx==5.2.3
     # via
     #   -c time-series-metadata/requirements/dev-requirements.in
     #   -r agentMET4FOF/dev-requirements.in


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after all subtrees were       successfully updated and afterwards the deps       were succesfully compiled. If all tests pass with the       new versions, it should be merged as soon as possible to       avoid any security issues due to outdated dependencies.