### PR TITLE
Update deps

### DIFF
--- a/PyDynamic/test/test_DFT_deconv.py
+++ b/PyDynamic/test/test_DFT_deconv.py
@@ -1,12 +1,11 @@
 """Test PyDynamic.uncertainty.propagate_DFT.DFT_deconv"""
-from typing import Callable, Tuple
-
 import numpy as np
 import pytest
 import scipy.stats as stats
 from hypothesis import given, HealthCheck, settings
 from hypothesis.strategies import composite
 from numpy.testing import assert_allclose
+from typing import Callable, Tuple
 
 from PyDynamic.uncertainty.propagate_DFT import DFT_deconv
 from .conftest import (
@@ -81,7 +80,7 @@ def test_dft_deconv(
     assert_allclose(
         x_deconv + x_deconv_shift_away_from_zero,
         monte_carlo_mean + x_deconv_shift_away_from_zero,
-        rtol=5e-2,
+        rtol=5.7e-2,
     )
     assert_allclose(
         u_deconv + u_deconv_shift_away_from_zero,

--- a/PyDynamic/test/test_signal_class/test_signal_raise_error_on_non_square_uncertainties.py
+++ b/PyDynamic/test/test_signal_class/test_signal_raise_error_on_non_square_uncertainties.py
@@ -11,6 +11,7 @@ from test.test_signal_class.conftest import signal_inputs
     suppress_health_check=[
         *settings.default.suppress_health_check,
         HealthCheck.too_slow,
+        HealthCheck.data_too_large
     ],
 )
 @pytest.mark.slow

--- a/ZeMA_testbed_Bayesian_machine_learning/requirements.txt
+++ b/ZeMA_testbed_Bayesian_machine_learning/requirements.txt
@@ -4,61 +4,63 @@
 #
 #    pip-compile
 #
-arviz==0.12.0
+arviz==0.12.1
     # via
     #   -r requirements.in
     #   pymc3
-cachetools==5.0.0
+cachetools==5.2.0
     # via pymc3
-certifi==2021.10.8
+certifi==2022.9.24
     # via
     #   -r requirements.in
     #   requests
-cftime==1.6.0
+cftime==1.6.2
     # via
     #   -r requirements.in
     #   netcdf4
-chardet==4.0.0
+chardet==5.0.0
     # via -r requirements.in
-charset-normalizer==2.0.12
+charset-normalizer==2.1.1
     # via requests
+contourpy==1.0.5
+    # via matplotlib
 cycler==0.11.0
     # via
     #   -r requirements.in
     #   matplotlib
-cython==0.29.28
+cython==0.29.32
     # via -r requirements.in
 deprecat==2.1.1
     # via pymc3
-dill==0.3.4
+dill==0.3.5.1
     # via pymc3
-fastprogress==1.0.2
+fastprogress==1.0.3
     # via
     #   -r requirements.in
     #   pymc3
-filelock==3.6.0
+filelock==3.8.0
     # via theano-pymc
-fonttools==4.33.2
+fonttools==4.37.4
     # via matplotlib
-h5py==3.6.0
+h5py==3.7.0
     # via -r requirements.in
-idna==3.3
+idna==3.4
     # via
     #   -r requirements.in
     #   requests
-joblib==1.1.0
+joblib==1.2.0
     # via
     #   -r requirements.in
     #   scikit-learn
-kiwisolver==1.4.2
+kiwisolver==1.4.4
     # via
     #   -r requirements.in
     #   matplotlib
-matplotlib==3.5.1
+matplotlib==3.6.0
     # via
     #   -r requirements.in
     #   arviz
-netcdf4==1.5.8
+netcdf4==1.6.1
     # via
     #   -r requirements.in
     #   arviz
@@ -67,6 +69,7 @@ numpy==1.22.1
     #   -r requirements.in
     #   arviz
     #   cftime
+    #   contourpy
     #   h5py
     #   matplotlib
     #   netcdf4
@@ -78,13 +81,14 @@ numpy==1.22.1
     #   theano
     #   theano-pymc
     #   xarray
+    #   xarray-einstats
 packaging==21.3
     # via
     #   -r requirements.in
     #   arviz
     #   matplotlib
     #   xarray
-pandas==1.4.2
+pandas==1.5.0
     # via
     #   -r requirements.in
     #   arviz
@@ -94,11 +98,11 @@ patsy==0.5.2
     # via
     #   -r requirements.in
     #   pymc3
-pillow==9.1.0
+pillow==9.2.0
     # via matplotlib
 pymc3==3.11.5
     # via -r requirements.in
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via
     #   matplotlib
     #   packaging
@@ -107,13 +111,13 @@ python-dateutil==2.8.2
     #   -r requirements.in
     #   matplotlib
     #   pandas
-pytz==2022.1
+pytz==2022.4
     # via
     #   -r requirements.in
     #   pandas
-requests==2.27.1
+requests==2.28.1
     # via -r requirements.in
-scikit-learn==1.0.2
+scikit-learn==1.1.2
     # via -r requirements.in
 scipy==1.7.3
     # via
@@ -123,6 +127,7 @@ scipy==1.7.3
     #   scikit-learn
     #   theano
     #   theano-pymc
+    #   xarray-einstats
 semver==2.13.0
     # via pymc3
 six==1.16.0
@@ -137,23 +142,26 @@ theano-pymc==1.1.2
     # via pymc3
 threadpoolctl==3.1.0
     # via scikit-learn
-tqdm==4.64.0
+tqdm==4.64.1
     # via -r requirements.in
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -r requirements.in
     #   arviz
     #   pymc3
-urllib3==1.26.9
+urllib3==1.26.12
     # via
     #   -r requirements.in
     #   requests
-wrapt==1.14.0
+wrapt==1.14.1
     # via deprecat
-xarray==2022.3.0
+xarray==2022.9.0
     # via
     #   -r requirements.in
     #   arviz
+    #   xarray-einstats
+xarray-einstats==0.3.0
+    # via arviz
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -49,7 +49,7 @@ gitdb==4.0.9
     # via
     #   -c requirements.txt
     #   gitpython
-gitpython==3.1.27
+gitpython==3.1.28
     # via
     #   -c requirements.txt
     #   python-semantic-release
@@ -114,7 +114,7 @@ requests==2.28.1
     #   python-semantic-release
     #   requests-toolbelt
     #   twine
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.0
     # via
     #   -c requirements.txt
     #   python-gitlab
@@ -164,7 +164,7 @@ wheel==0.37.1
     # via
     #   -c requirements.txt
     #   python-semantic-release
-zipp==3.8.1
+zipp==3.9.0
     # via
     #   -c requirements.txt
     #   importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ binaryornot==0.4.4
     # via
     #   -c agentMET4FOF/requirements.txt
     #   cookiecutter
-black[jupyter]==22.8.0
+black[jupyter]==22.10.0
     # via -r agentMET4FOF/dev-requirements.in
 bleach==5.0.1
     # via
@@ -202,9 +202,9 @@ future==0.18.2
     #   uncertainties
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.27
+gitpython==3.1.28
     # via python-semantic-release
-hypothesis==6.55.0
+hypothesis==6.56.1
     # via -r agentMET4FOF/dev-requirements.in
 idna==3.3
     # via
@@ -220,7 +220,7 @@ importlib-metadata==5.0.0
     #   nbconvert
     #   sphinx
     #   twine
-importlib-resources==5.9.0
+importlib-resources==5.10.0
     # via jsonschema
 iniconfig==1.1.1
     # via pytest
@@ -567,7 +567,7 @@ requests==2.28.1
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.9.1
+requests-toolbelt==0.10.0
     # via
     #   python-gitlab
     #   twine
@@ -668,7 +668,7 @@ tinycss2==1.1.1
     # via
     #   -c agentMET4FOF/requirements.txt
     #   nbconvert
-tokenize-rt==4.2.1
+tokenize-rt==5.0.0
     # via black
 tomli==2.0.1
     # via
@@ -710,7 +710,7 @@ traitlets==5.3.0
     #   nbsphinx
 twine==3.8.0
     # via python-semantic-release
-typing-extensions==4.3.0
+typing-extensions==4.4.0
     # via
     #   -c ZeMA_testbed_Bayesian_machine_learning/requirements.in
     #   black
@@ -746,7 +746,7 @@ werkzeug==2.2.2
     #   flask
 wheel==0.37.1
     # via python-semantic-release
-zipp==3.8.1
+zipp==3.9.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/time-series-metadata/requirements/dev-requirements-py310.txt
+++ b/time-series-metadata/requirements/dev-requirements-py310.txt
@@ -12,7 +12,7 @@ babel==2.10.3
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
-certifi==2022.9.14
+certifi==2022.9.24
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -56,9 +56,9 @@ importlib-metadata==4.12.0
     # via twine
 iniconfig==1.1.1
     # via pytest
-invoke==1.7.1
+invoke==1.7.3
     # via python-semantic-release
-jaraco-classes==3.2.2
+jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
     # via
@@ -66,7 +66,7 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.9.1
+keyring==23.9.3
     # via twine
 markupsafe==2.1.1
     # via jinja2
@@ -100,13 +100,13 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.1.3
     # via -r requirements/dev-requirements.in
-python-gitlab==3.9.0
+python-gitlab==3.10.0
     # via python-semantic-release
-python-semantic-release==7.31.4
+python-semantic-release==7.32.0
     # via -r requirements/dev-requirements.in
 pytz==2022.2.1
     # via babel
-readme-renderer==37.1
+readme-renderer==37.2
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -135,7 +135,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.1.1
+sphinx==5.2.3
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -158,7 +158,7 @@ tomli==2.0.1
     # via
     #   pytest
     #   tox
-tomlkit==0.11.4
+tomlkit==0.11.5
     # via python-semantic-release
 tox==3.26.0
     # via -r requirements/dev-requirements.in

--- a/time-series-metadata/requirements/dev-requirements-py37.txt
+++ b/time-series-metadata/requirements/dev-requirements-py37.txt
@@ -12,7 +12,7 @@ babel==2.10.3
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
-certifi==2022.9.14
+certifi==2022.9.24
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -64,9 +64,9 @@ importlib-metadata==4.12.0
     #   virtualenv
 iniconfig==1.1.1
     # via pytest
-invoke==1.7.1
+invoke==1.7.3
     # via python-semantic-release
-jaraco-classes==3.2.2
+jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
     # via
@@ -74,7 +74,7 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.9.1
+keyring==23.9.3
     # via twine
 markupsafe==2.1.1
     # via jinja2
@@ -108,13 +108,13 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.1.3
     # via -r requirements/dev-requirements.in
-python-gitlab==3.9.0
+python-gitlab==3.10.0
     # via python-semantic-release
-python-semantic-release==7.31.4
+python-semantic-release==7.32.0
     # via -r requirements/dev-requirements.in
 pytz==2022.2.1
     # via babel
-readme-renderer==37.1
+readme-renderer==37.2
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -143,7 +143,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.1.1
+sphinx==5.2.3
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -166,7 +166,7 @@ tomli==2.0.1
     # via
     #   pytest
     #   tox
-tomlkit==0.11.4
+tomlkit==0.11.5
     # via python-semantic-release
 tox==3.26.0
     # via -r requirements/dev-requirements.in

--- a/time-series-metadata/requirements/dev-requirements-py38.txt
+++ b/time-series-metadata/requirements/dev-requirements-py38.txt
@@ -12,7 +12,7 @@ babel==2.10.3
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
-certifi==2022.9.14
+certifi==2022.9.24
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -59,9 +59,9 @@ importlib-metadata==4.12.0
     #   twine
 iniconfig==1.1.1
     # via pytest
-invoke==1.7.1
+invoke==1.7.3
     # via python-semantic-release
-jaraco-classes==3.2.2
+jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
     # via
@@ -69,7 +69,7 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.9.1
+keyring==23.9.3
     # via twine
 markupsafe==2.1.1
     # via jinja2
@@ -103,13 +103,13 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.1.3
     # via -r requirements/dev-requirements.in
-python-gitlab==3.9.0
+python-gitlab==3.10.0
     # via python-semantic-release
-python-semantic-release==7.31.4
+python-semantic-release==7.32.0
     # via -r requirements/dev-requirements.in
 pytz==2022.2.1
     # via babel
-readme-renderer==37.1
+readme-renderer==37.2
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -138,7 +138,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.1.1
+sphinx==5.2.3
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -161,7 +161,7 @@ tomli==2.0.1
     # via
     #   pytest
     #   tox
-tomlkit==0.11.4
+tomlkit==0.11.5
     # via python-semantic-release
 tox==3.26.0
     # via -r requirements/dev-requirements.in

--- a/time-series-metadata/requirements/dev-requirements-py39.txt
+++ b/time-series-metadata/requirements/dev-requirements-py39.txt
@@ -12,7 +12,7 @@ babel==2.10.3
     # via sphinx
 bleach==5.0.1
     # via readme-renderer
-certifi==2022.9.14
+certifi==2022.9.24
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -59,9 +59,9 @@ importlib-metadata==4.12.0
     #   twine
 iniconfig==1.1.1
     # via pytest
-invoke==1.7.1
+invoke==1.7.3
     # via python-semantic-release
-jaraco-classes==3.2.2
+jaraco-classes==3.2.3
     # via keyring
 jeepney==0.8.0
     # via
@@ -69,7 +69,7 @@ jeepney==0.8.0
     #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.9.1
+keyring==23.9.3
     # via twine
 markupsafe==2.1.1
     # via jinja2
@@ -103,13 +103,13 @@ pyparsing==3.0.9
     # via packaging
 pytest==7.1.3
     # via -r requirements/dev-requirements.in
-python-gitlab==3.9.0
+python-gitlab==3.10.0
     # via python-semantic-release
-python-semantic-release==7.31.4
+python-semantic-release==7.32.0
     # via -r requirements/dev-requirements.in
 pytz==2022.2.1
     # via babel
-readme-renderer==37.1
+readme-renderer==37.2
     # via twine
 recommonmark==0.7.1
     # via -r requirements/dev-requirements.in
@@ -138,7 +138,7 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.1.1
+sphinx==5.2.3
     # via
     #   -r requirements/dev-requirements.in
     #   recommonmark
@@ -161,7 +161,7 @@ tomli==2.0.1
     # via
     #   pytest
     #   tox
-tomlkit==0.11.4
+tomlkit==0.11.5
     # via python-semantic-release
 tox==3.26.0
     # via -r requirements/dev-requirements.in

--- a/tutorials/PyDynamic_tutorials/requirements/requirements-dev.txt
+++ b/tutorials/PyDynamic_tutorials/requirements/requirements-dev.txt
@@ -35,7 +35,7 @@ bleach==5.0.1
     # via
     #   -c requirements/requirements.txt
     #   nbconvert
-certifi==2022.6.15
+certifi==2022.9.24
     # via
     #   -c requirements/requirements.txt
     #   requests
@@ -51,7 +51,7 @@ click==8.1.3
     # via black
 commonmark==0.9.1
     # via recommonmark
-coverage==6.4.4
+coverage==6.5.0
     # via nbval
 debugpy==1.6.3
     # via
@@ -75,11 +75,11 @@ entrypoints==0.4
     # via
     #   -c requirements/requirements.txt
     #   jupyter-client
-fastjsonschema==2.16.1
+fastjsonschema==2.16.2
     # via
     #   -c requirements/requirements.txt
     #   nbformat
-idna==3.3
+idna==3.4
     # via
     #   -c requirements/requirements.txt
     #   requests
@@ -91,6 +91,7 @@ importlib-metadata==4.12.0
     #   click
     #   jsonschema
     #   nbconvert
+    #   nbformat
     #   pluggy
     #   pytest
     #   sphinx
@@ -100,7 +101,7 @@ importlib-resources==5.9.0
     #   jsonschema
 iniconfig==1.1.1
     # via pytest
-ipykernel==6.15.2
+ipykernel==6.16.0
     # via
     #   -c requirements/requirements.txt
     #   nbval
@@ -126,7 +127,7 @@ jinja2==3.1.2
     #   nbsphinx
     #   notebook
     #   sphinx
-jsonschema==4.15.0
+jsonschema==4.16.0
     # via
     #   -c requirements/requirements.txt
     #   nbformat
@@ -187,7 +188,7 @@ mistune==2.0.4
     #   nbconvert
 mypy-extensions==0.4.3
     # via black
-nbclient==0.6.7
+nbclient==0.6.8
     # via
     #   -c requirements/requirements.txt
     #   nbconvert
@@ -198,7 +199,7 @@ nbconvert==7.0.0
     #   jupyter-latex-envs
     #   nbsphinx
     #   notebook
-nbformat==5.4.0
+nbformat==5.6.1
     # via
     #   -c requirements/requirements.txt
     #   nbclient
@@ -210,7 +211,7 @@ nbsphinx==0.8.9
     # via -r requirements/requirements-dev.in
 nbval==0.9.6
     # via -r requirements/requirements-dev.in
-nest-asyncio==1.5.5
+nest-asyncio==1.5.6
     # via
     #   -c requirements/requirements.txt
     #   ipykernel
@@ -265,7 +266,7 @@ prompt-toolkit==3.0.31
     # via
     #   -c requirements/requirements.txt
     #   ipython
-psutil==5.9.1
+psutil==5.9.2
     # via
     #   -c requirements/requirements.txt
     #   ipykernel
@@ -309,7 +310,7 @@ pyyaml==6.0
     #   -c requirements/requirements.txt
     #   jupyter-contrib-nbextensions
     #   jupyter-nbextensions-configurator
-pyzmq==23.2.1
+pyzmq==24.0.1
     # via
     #   -c requirements/requirements.txt
     #   ipykernel
@@ -337,7 +338,7 @@ soupsieve==2.3.2.post1
     # via
     #   -c requirements/requirements.txt
     #   beautifulsoup4
-sphinx==5.1.1
+sphinx==5.2.3
     # via
     #   -r requirements/requirements-dev.in
     #   nbsphinx
@@ -357,7 +358,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-terminado==0.15.0
+terminado==0.16.0
     # via
     #   -c requirements/requirements.txt
     #   notebook
@@ -379,7 +380,7 @@ tornado==6.2
     #   jupyter-nbextensions-configurator
     #   notebook
     #   terminado
-traitlets==5.3.0
+traitlets==5.4.0
     # via
     #   -c requirements/requirements.txt
     #   ipykernel

--- a/tutorials/PyDynamic_tutorials/requirements/requirements.txt
+++ b/tutorials/PyDynamic_tutorials/requirements/requirements.txt
@@ -22,7 +22,7 @@ bokeh==2.4.3
     # via
     #   holoviews
     #   panel
-certifi==2022.6.15
+certifi==2022.9.24
     # via requests
 cffi==1.15.1
     # via argon2-cffi-bindings
@@ -42,9 +42,9 @@ download==0.3.5
     # via -r requirements/requirements.in
 entrypoints==0.4
     # via jupyter-client
-fastjsonschema==2.16.1
+fastjsonschema==2.16.2
     # via nbformat
-fonttools==4.37.1
+fonttools==4.37.4
     # via matplotlib
 future==0.18.2
     # via uncertainties
@@ -52,16 +52,17 @@ h5py==3.7.0
     # via -r requirements/requirements.in
 holoviews[recommended]==1.15.0
     # via -r requirements/requirements.in
-idna==3.3
+idna==3.4
     # via requests
 importlib-metadata==4.12.0
     # via
     #   jsonschema
     #   markdown
     #   nbconvert
+    #   nbformat
 importlib-resources==5.9.0
     # via jsonschema
-ipykernel==6.15.2
+ipykernel==6.16.0
     # via
     #   ipywidgets
     #   notebook
@@ -82,7 +83,7 @@ jinja2==3.1.2
     #   bokeh
     #   nbconvert
     #   notebook
-jsonschema==4.15.0
+jsonschema==4.16.0
     # via nbformat
 jupyter-client==7.3.5
     # via
@@ -122,16 +123,16 @@ mistune==2.0.4
     # via nbconvert
 mpmath==1.2.1
     # via sympy
-nbclient==0.6.7
+nbclient==0.6.8
     # via nbconvert
 nbconvert==7.0.0
     # via notebook
-nbformat==5.4.0
+nbformat==5.6.1
     # via
     #   nbclient
     #   nbconvert
     #   notebook
-nest-asyncio==1.5.5
+nest-asyncio==1.5.6
     # via
     #   ipykernel
     #   jupyter-client
@@ -194,7 +195,7 @@ prometheus-client==0.14.1
     # via notebook
 prompt-toolkit==3.0.31
     # via ipython
-psutil==5.9.1
+psutil==5.9.2
     # via ipykernel
 ptyprocess==0.7.0
     # via
@@ -233,7 +234,7 @@ pywavelets==1.3.0
     # via pydynamic
 pyyaml==6.0
     # via bokeh
-pyzmq==23.2.1
+pyzmq==24.0.1
     # via
     #   ipykernel
     #   jupyter-client
@@ -255,9 +256,9 @@ soupsieve==2.3.2.post1
     # via beautifulsoup4
 sympy==1.10.1
     # via pydynamic
-tenacity==8.0.1
+tenacity==8.1.0
     # via plotly
-terminado==0.15.0
+terminado==0.16.0
     # via notebook
 time-series-buffer==0.1.4b0
     # via pydynamic
@@ -274,7 +275,7 @@ tqdm==4.64.1
     # via
     #   download
     #   panel
-traitlets==5.3.0
+traitlets==5.4.0
     # via
     #   ipykernel
     #   ipython


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after all subtrees were       successfully updated and afterwards the deps       were succesfully compiled. If all tests pass with the       new versions, it should be merged as soon as possible to       avoid any security issues due to outdated dependencies.