### PR TITLE
Update deps

### DIFF
--- a/PyDynamic/test/test_DFT_deconv.py
+++ b/PyDynamic/test/test_DFT_deconv.py
@@ -85,7 +85,7 @@ def test_dft_deconv(
     assert_allclose(
         u_deconv + u_deconv_shift_away_from_zero,
         monte_carlo_cov + u_deconv_shift_away_from_zero,
-        rtol=1.69e-1,
+        rtol=2.56e-1,
     )
 
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -49,7 +49,7 @@ gitdb==4.0.9
     # via
     #   -c requirements.txt
     #   gitpython
-gitpython==3.1.28
+gitpython==3.1.29
     # via
     #   -c requirements.txt
     #   python-semantic-release

--- a/requirements.txt
+++ b/requirements.txt
@@ -202,9 +202,9 @@ future==0.18.2
     #   uncertainties
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.28
+gitpython==3.1.29
     # via python-semantic-release
-hypothesis==6.56.1
+hypothesis==6.56.2
     # via -r agentMET4FOF/dev-requirements.in
 idna==3.3
     # via


### PR DESCRIPTION
This PR provides recompiled deps for all outdated       package versions. It was opened after all subtrees were       successfully updated and afterwards the deps       were succesfully compiled. If all tests pass with the       new versions, it should be merged as soon as possible to       avoid any security issues due to outdated dependencies.